### PR TITLE
RCH-2 Improve Input System

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::game::board::Board;
+use crate::game::board::{board_display, Board};
 use crate::game::moves::Move;
 use crate::game::piece::piece_info::PieceLoc;
 use std::io::{self, Write};
@@ -14,21 +14,12 @@ fn get_input(prompt: &str) -> io::Result<String> {
 }
 
 fn prompt_location() -> Option<PieceLoc> {
-    if let (Ok(rank), Ok(file)) = (
-        get_input("Enter piece rank (1-8): "),
-        get_input("Enter piece file (1-8): "),
-    ) {
-        let rank = rank.trim().parse::<u8>();
-        let file = file.trim().parse::<u8>();
-
-        // If both values are valid u8's and within the board's size, return a valid location
-        if let (Some(rank), Some(file)) = (rank.ok(), file.ok()) {
-            if PieceLoc::is_valid(rank - 1, file - 1) {
-                return Some(PieceLoc::new(rank - 1, file - 1));
-            }
-        }
+    if let Ok(position) = get_input("Enter piece position (i.e. A1, E5): ") {
+        let position = position.trim();
+        let position = PieceLoc::from_notation(position);
+        return position;
     }
-    println!("Please enter a valid rank and file, from 1-8.");
+    println!("Please enter a valid rank and file, from A-H, 1-8.");
     None
 }
 


### PR DESCRIPTION
Input system now expects rank+file combos instead of individual prompts for rank and file. This means instead of the following inputs to move Pawn E2 to E3:
```
2 *enter*
5 *enter*
4 *enter*
5 *enter*
```
We now do:
```
E2 *enter*
E4 *enter*
```