### PR TITLE
RCH-9 Fix Pawns moving like Knights

### DIFF
--- a/src/game/moves/move_checker.rs
+++ b/src/game/moves/move_checker.rs
@@ -181,7 +181,7 @@ pub fn is_valid_move(
                 }
             } else {
                 if start.file != dest.file {
-                    return Err(MoveError::PawnMustCaptureDiagonal);
+                    return Err(MoveError::PawnMustMoveForward);
                 }
             }
 


### PR DESCRIPTION
Couldn't replicate error, but found issue with movement error messages, so fixed that instead.