### PR TITLE
RCH-15 Add has_moved property

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,9 @@ pub fn prompt_make_move(game: &Board) -> Option<Move> {
 
             if let Some(target_location) = prompt_location() {
                 println!("Target chosen.");
-                return Some(Move::new(piece, location, target_location));
+                if let Ok(new_move) = Move::new(game, &piece, &location, &target_location) {
+                    return Some(new_move);
+                }
             }
         } else {
             println!("No piece found at ({location:?})");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,9 +29,13 @@ pub fn prompt_make_move(game: &Board) -> Option<Move> {
             println!("Piece found: {:?}", piece);
 
             if let Some(target_location) = prompt_location() {
-                println!("Target chosen.");
-                if let Ok(new_move) = Move::new(game, &piece, &location, &target_location) {
-                    return Some(new_move);
+                let new_move = Move::new(game, &piece, &location, &target_location);
+                match new_move {
+                    Ok(m) => return Some(m),
+                    Err(e) => {
+                        println!("{}", e);
+                        return None;
+                    }
                 }
             }
         } else {

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -117,25 +117,28 @@ impl Board {
         &mut self,
         m: &Move,
     ) -> HashMap<PieceColor, HashMap<PieceType, u8>> {
-        match m.move_type {
-            MoveType::Normal | MoveType::EnPassant => {
-                if let Some(captured_piece_idx) = self.get_captured_piece_idx(m) {
-                    if let Some(captured_piece) = self.board[captured_piece_idx] {
-                        let mut new_graveyard = self.graveyard.clone();
-                        let color_grave = new_graveyard
-                            .get_mut(&captured_piece.color)
-                            .expect("Didn't find color in graveyard");
-                        let piece_grave = color_grave.entry(captured_piece.piece_type).or_insert(1);
-                        *piece_grave += 1;
+        if m.capturing {
+            match m.move_type {
+                MoveType::Normal | MoveType::EnPassant => {
+                    if let Some(captured_piece_idx) = self.get_captured_piece_idx(m) {
+                        if let Some(captured_piece) = self.board[captured_piece_idx] {
+                            let mut new_graveyard = self.graveyard.clone();
+                            let color_grave = new_graveyard
+                                .get_mut(&captured_piece.color)
+                                .expect("Didn't find color in graveyard");
+                            let piece_grave =
+                                color_grave.entry(captured_piece.piece_type).or_insert(1);
+                            *piece_grave += 1;
 
-                        self.board[captured_piece_idx] = None;
-                        return new_graveyard;
-                    } else {
-                        panic!("Somehow captured piece that didn't exist.");
+                            self.board[captured_piece_idx] = None;
+                            return new_graveyard;
+                        } else {
+                            panic!("Somehow captured piece that didn't exist.");
+                        }
                     }
                 }
+                _ => (),
             }
-            _ => (),
         }
         // Fallback to returning the old graveyard if no capture happened
         self.graveyard.clone()

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -135,7 +135,7 @@ impl Board {
     }
 
     pub fn move_piece(mut self, new_move: Move) -> Board {
-        let selected_piece = new_move.piece;
+        let mut selected_piece = new_move.piece;
         let is_valid_move = move_checker::is_valid_move(
             &self,
             &selected_piece,
@@ -163,11 +163,19 @@ impl Board {
 
                         new_board[captured_piece_idx] = None;
                     } else {
-                        panic!("Somehow captured peice that didn't exist.");
+                        panic!("Somehow captured piece that didn't exist.");
                     }
                 }
-                new_board[end_board_idx] = new_board[start_board_idx];
+
+                selected_piece.has_moved = true;
+                new_board[end_board_idx] = Some(selected_piece);
                 new_board[start_board_idx] = None;
+
+                // Update the moved piece's has_moved flag
+                if let Some(_piece) = new_board[end_board_idx] {
+                    new_board[end_board_idx].unwrap().has_moved = true;
+                }
+
                 return self.update(new_board, new_move_list, new_graveyard);
             }
             Err(error) => {

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -117,7 +117,36 @@ impl Board {
         new_move_list
     }
 
-    fn get_captured_piece_idx(&self, result: CaptureResult, m: Move) -> Option<usize> {
+    fn handle_move_piece_to_graveyard(
+        &mut self,
+        capture_type: &CaptureResult,
+        m: &Move,
+    ) -> HashMap<PieceColor, HashMap<PieceType, u8>> {
+        match capture_type {
+            CaptureResult::Normal | CaptureResult::EnPassant => {
+                if let Some(captured_piece_idx) = self.get_captured_piece_idx(capture_type, m) {
+                    if let Some(captured_piece) = self.board[captured_piece_idx] {
+                        let mut new_graveyard = self.graveyard.clone();
+                        let color_grave = new_graveyard
+                            .get_mut(&captured_piece.color)
+                            .expect("Didn't find color in graveyard");
+                        let piece_grave = color_grave.entry(captured_piece.piece_type).or_insert(1);
+                        *piece_grave += 1;
+
+                        self.board[captured_piece_idx] = None;
+                        return new_graveyard;
+                    } else {
+                        panic!("Somehow captured piece that didn't exist.");
+                    }
+                }
+            }
+            _ => (),
+        }
+        // Fallback to returning the old graveyard if no capture happened
+        self.graveyard.clone()
+    }
+
+    fn get_captured_piece_idx(&self, result: &CaptureResult, m: &Move) -> Option<usize> {
         match result {
             CaptureResult::Normal => Some(self.get_board_index_from_loc(m.end_pos)),
             CaptureResult::EnPassant => match m.piece.color {
@@ -134,47 +163,36 @@ impl Board {
         }
     }
 
+    fn handle_moving_piece(&self, m: &Move) -> Vec<Option<Piece>> {
+        let mut new_board = self.board.clone();
+        let mut selected_piece = m.piece;
+
+        let start_board_idx = self.get_board_index_from_loc(m.start_pos);
+        let end_board_idx = self.get_board_index_from_loc(m.end_pos);
+
+        selected_piece.has_moved = true;
+        new_board[end_board_idx] = Some(selected_piece);
+        new_board[start_board_idx] = None;
+
+        // Update the moved piece's has_moved flag
+        if let Some(_piece) = new_board[end_board_idx] {
+            new_board[end_board_idx].unwrap().has_moved = true;
+        }
+        new_board
+    }
+
     pub fn move_piece(mut self, new_move: Move) -> Board {
-        let mut selected_piece = new_move.piece;
         let is_valid_move = move_checker::is_valid_move(
             &self,
-            &selected_piece,
+            &new_move.piece,
             &new_move.start_pos,
             &new_move.end_pos,
         );
         match is_valid_move {
             Ok(capturing_move) => {
                 let new_move_list = self.record_move(&new_move);
-                let mut new_board = self.board.clone();
-                let mut new_graveyard = self.graveyard.clone();
-
-                let start_board_idx = self.get_board_index_from_loc(new_move.start_pos);
-                let end_board_idx = self.get_board_index_from_loc(new_move.end_pos);
-
-                if let Some(captured_piece_idx) =
-                    self.get_captured_piece_idx(capturing_move, new_move)
-                {
-                    if let Some(captured_piece) = new_board[captured_piece_idx] {
-                        let color_grave = new_graveyard
-                            .get_mut(&captured_piece.color)
-                            .expect("Didn't find color in graveyard");
-                        let piece_grave = color_grave.entry(captured_piece.piece_type).or_insert(1);
-                        *piece_grave += 1;
-
-                        new_board[captured_piece_idx] = None;
-                    } else {
-                        panic!("Somehow captured piece that didn't exist.");
-                    }
-                }
-
-                selected_piece.has_moved = true;
-                new_board[end_board_idx] = Some(selected_piece);
-                new_board[start_board_idx] = None;
-
-                // Update the moved piece's has_moved flag
-                if let Some(_piece) = new_board[end_board_idx] {
-                    new_board[end_board_idx].unwrap().has_moved = true;
-                }
+                let new_board = self.handle_moving_piece(&new_move);
+                let new_graveyard = self.handle_move_piece_to_graveyard(&capturing_move, &new_move);
 
                 return self.update(new_board, new_move_list, new_graveyard);
             }

--- a/src/game/moves.rs
+++ b/src/game/moves.rs
@@ -1,13 +1,20 @@
-use crate::game::board;
+use crate::game::board::{self, Board};
 use crate::game::piece::{piece_info::PieceLoc, Piece};
+
+use self::move_checker::MoveError;
 
 pub mod move_checker;
 
-#[derive(PartialEq, Debug)]
-pub enum CaptureResult {
+#[derive(Clone, PartialEq, Debug)]
+pub enum MoveType {
     Normal,
     EnPassant,
-    None,
+    Castling,
+}
+
+pub struct MoveResult {
+    move_type: MoveType,
+    capturing: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -15,14 +22,29 @@ pub struct Move {
     pub piece: Piece,
     pub start_pos: PieceLoc,
     pub end_pos: PieceLoc,
+    pub move_type: MoveType,
+    pub capturing: bool,
 }
 
 impl Move {
-    pub fn new(piece: Piece, start: PieceLoc, dest: PieceLoc) -> Move {
-        Move {
-            piece: piece.clone(),
-            start_pos: start.clone(),
-            end_pos: dest.clone(),
+    // Creates a move, checking first that the move is valid on the given board. This ensures
+    // we cannot ever create an invalid move.
+    pub fn new(
+        board: &Board,
+        piece: &Piece,
+        start: &PieceLoc,
+        dest: &PieceLoc,
+    ) -> Result<Move, MoveError> {
+        let move_result = move_checker::is_valid_move(board, piece, start, dest);
+        match move_result {
+            Ok(result) => Ok(Move {
+                piece: piece.clone(),
+                start_pos: start.clone(),
+                end_pos: dest.clone(),
+                move_type: result.move_type.clone(),
+                capturing: result.capturing,
+            }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/game/moves.rs
+++ b/src/game/moves.rs
@@ -1,21 +1,9 @@
 use crate::game::board::{self, Board};
 use crate::game::piece::{piece_info::PieceLoc, Piece};
 
-use self::move_checker::MoveError;
+use self::move_checker::{MoveError, MoveType};
 
 pub mod move_checker;
-
-#[derive(Clone, PartialEq, Debug)]
-pub enum MoveType {
-    Normal,
-    EnPassant,
-    Castling,
-}
-
-pub struct MoveResult {
-    move_type: MoveType,
-    capturing: bool,
-}
 
 #[derive(Clone, Debug)]
 pub struct Move {

--- a/src/game/moves/move_checker.rs
+++ b/src/game/moves/move_checker.rs
@@ -239,16 +239,18 @@ pub fn is_valid_move(
                     return Err(MoveError::CannotCastleWithMovedKing);
                 }
 
-                let castling_rook;
+                let castling_rook_index;
                 if dest.file < start.file {
                     // Castling queenside
-                    castling_rook = board.get_piece_at_location(PieceLoc::new(dest.rank, 0));
+                    castling_rook_index = 0;
                 } else {
                     // Castling kingside
-                    castling_rook = board.get_piece_at_location(PieceLoc::new(dest.rank, 7));
+                    castling_rook_index = 7;
                 }
 
-                if let Some(rook) = castling_rook {
+                if let Some(rook) =
+                    board.get_piece_at_location(PieceLoc::new(dest.rank, castling_rook_index))
+                {
                     if !rook.has_moved {
                         move_type = MoveType::Castling;
                         Ok(MoveResult {

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -98,6 +98,7 @@ pub mod piece_info {
 pub struct Piece {
     pub piece_type: piece_info::PieceType,
     pub color: piece_info::PieceColor,
+    pub has_moved: bool,
 }
 
 impl Piece {
@@ -105,13 +106,18 @@ impl Piece {
         Piece {
             piece_type: p_type,
             color,
+            has_moved: false,
         }
     }
 }
 
 impl fmt::Display for Piece {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}", self.color, self.piece_type)
+        write!(
+            f,
+            "{} {}, has moved: {}",
+            self.color, self.piece_type, self.has_moved
+        )
     }
 }
 
@@ -120,6 +126,7 @@ impl fmt::Debug for Piece {
         f.debug_struct("Piece")
             .field("Type", &self.piece_type)
             .field("Color", &self.color)
+            .field("has_moved", &self.has_moved)
             .finish()
     }
 }


### PR DESCRIPTION
Added the `has_moved` property to pieces to help with determining legal moves. In particular, it helps confirm:
1. Pawns cannot move two squares once they have moved once
2. Kings cannot castle if they have moved
3. Rooks cannot be used to castle if they have moved.